### PR TITLE
break out packaging from publishing script

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+TAR_PATH=/tmp/release
+TAR_FILE=/tmp/release.tar.gz
+
+mkdir -p $TAR_PATH
+mkdir -p $TAR_PATH/include
+mkdir -p $TAR_PATH/lib/pkgconfig
+
+cp target/release/libbls_signatures.h $TAR_PATH/include/
+cp target/release/libbls_signatures_ffi.a $TAR_PATH/lib/libbls_signatures.a
+cp target/release/libbls_signatures.pc $TAR_PATH/lib/pkgconfig
+
+pushd $TAR_PATH
+
+tar -czf $TAR_FILE ./*
+
+popd

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
-TAR_PATH=/tmp/release
-TAR_FILE=/tmp/release.tar.gz
+if [ -z "$1" ]; then
+  TAR_FILE=`mktemp`.tar.gz
+else
+  TAR_FILE=$1
+fi
+
+TAR_PATH=`mktemp -d`
 
 mkdir -p $TAR_PATH
 mkdir -p $TAR_PATH/include
@@ -16,3 +21,7 @@ pushd $TAR_PATH
 tar -czf $TAR_FILE ./*
 
 popd
+
+rm -rf $TAR_PATH
+
+echo $TAR_FILE

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -19,9 +19,7 @@ fi
 
 echo "preparing release file"
 
-`dirname $0`/package-release.sh
-
-mv /tmp/release.tar.gz $RELEASE_FILE
+`dirname $0`/package-release.sh "$RELEASE_FILE"
 
 echo "release file created: $RELEASE_FILE"
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -2,8 +2,7 @@
 
 RELEASE_BRANCH="master"
 RELEASE_NAME="$CIRCLE_PROJECT_REPONAME-`uname`"
-RELEASE_PATH="$CIRCLE_ARTIFACTS/$RELEASE_NAME"
-RELEASE_FILE="$RELEASE_PATH.tar.gz"
+RELEASE_FILE="/tmp/$RELEASE_NAME.tar.gz"
 RELEASE_TAG="${CIRCLE_SHA1:0:16}"
 
 # make sure we're on the sanctioned branch
@@ -20,19 +19,9 @@ fi
 
 echo "preparing release file"
 
-mkdir $RELEASE_PATH
-mkdir $RELEASE_PATH/include
-mkdir -p $RELEASE_PATH/lib/pkgconfig
+`dirname $0`/package-release.sh
 
-cp target/release/libbls_signatures.h $RELEASE_PATH/include/
-cp target/release/libbls_signatures_ffi.a $RELEASE_PATH/lib/libbls_signatures.a
-cp target/release/libbls_signatures.pc $RELEASE_PATH/lib/pkgconfig
-
-pushd $RELEASE_PATH
-
-tar -czf $RELEASE_FILE ./*
-
-popd
+mv /tmp/release.tar.gz $RELEASE_FILE
 
 echo "release file created: $RELEASE_FILE"
 


### PR DESCRIPTION
this is step 1i of https://github.com/filecoin-project/go-filecoin/issues/2441

easier access to publishing `tar`s will remove the need for go-filecoin to understand the file structure of its dependencies