### PR TITLE
perf: improve verification times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 bls-signatures-ffi/target
+*.profile

--- a/bls-signatures-ffi/Cargo.toml
+++ b/bls-signatures-ffi/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["staticlib"]
 bls-signatures = { path = ".." }
 rand = "0.4"
 libc = "0.2"
+rayon = "1.2.0"
 
 [build-dependencies]
 cbindgen = "0.6.8"


### PR DESCRIPTION
This reduces the verification times on my machine from > 5s to < 2s for `4000` messages.  (for running the benchmarks on go-bls-sigs`