### PR TITLE
Fix additive feature flag usage

### DIFF
--- a/bls-signatures-ffi/src/lib.rs
+++ b/bls-signatures-ffi/src/lib.rs
@@ -7,7 +7,7 @@ use bls_signatures::{
 #[cfg(feature = "blst")]
 use blstrs::{G2Affine, G2Compressed};
 use groupy::{CurveAffine, CurveProjective, EncodedPoint, GroupDecodingError};
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 use paired::bls12_381::{G2Affine, G2Compressed};
 use rand::rngs::OsRng;
 use rayon::prelude::*;

--- a/examples/verify.rs
+++ b/examples/verify.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 #[cfg(feature = "blst")]
 use blstrs::G2Projective as G2;
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 use paired::bls12_381::G2;
 
 use bls_signatures::*;

--- a/src/key.rs
+++ b/src/key.rs
@@ -4,13 +4,13 @@ use ff::PrimeField;
 use groupy::{CurveAffine, CurveProjective, EncodedPoint};
 use rand_core::{CryptoRng, RngCore};
 
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 use hkdf::Hkdf;
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 use paired::bls12_381::{Fr, FrRepr, G1Affine, G1Compressed, G1};
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 use paired::BaseFromRO;
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 use sha2::{digest::generic_array::typenum::U48, digest::generic_array::GenericArray, Sha256};
 
 #[cfg(feature = "blst")]
@@ -97,7 +97,7 @@ impl PrivateKey {
 
     /// Sign the given message.
     /// Calculated by `signature = hash_into_g2(message) * sk`
-    #[cfg(feature = "pairing")]
+    #[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
     pub fn sign<T: AsRef<[u8]>>(&self, message: T) -> Signature {
         let mut p = hash(message.as_ref());
         p.mul_assign(self.0);
@@ -126,7 +126,7 @@ impl PrivateKey {
 
     /// Get the public key for this private key.
     /// Calculated by `pk = g1 * sk`.
-    #[cfg(feature = "pairing")]
+    #[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
     pub fn public_key(&self) -> PublicKey {
         let mut pk = G1::one();
         pk.mul_assign(self.0);
@@ -220,7 +220,7 @@ impl Serialize for PublicKey {
 
 /// Generates a secret key as defined in
 /// https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-2.3
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 fn key_gen<T: AsRef<[u8]>>(data: T) -> Fr {
     // "BLS-SIG-KEYGEN-SALT-"
     const SALT: &[u8] = b"BLS-SIG-KEYGEN-SALT-";
@@ -301,7 +301,7 @@ mod tests {
             0x4a73baed5cb75109,
         ]);
 
-        #[cfg(feature = "pairing")]
+        #[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
         let expect = FrRepr([
             0xa9f8187b89e6d49a,
             0xf870f34063ce4b16,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[cfg(all(feature = "pairing", feature = "blst"))]
-compile_error!("only pairing or blst can be enabled");
-
 mod error;
 mod key;
 mod signature;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -5,9 +5,9 @@ use ff::Field;
 use groupy::{CurveAffine, CurveProjective, EncodedPoint};
 use rayon::prelude::*;
 
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 use paired::bls12_381::{Bls12, Fq12, G1Affine, G2Affine, G2Compressed, G2};
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 use paired::{Engine, ExpandMsgXmd, HashToCurve, PairingCurveAffine};
 
 #[cfg(feature = "blst")]
@@ -72,7 +72,7 @@ fn g2_from_slice(raw: &[u8]) -> Result<G2Affine, Error> {
 }
 
 /// Hash the given message, as used in the signature.
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 pub fn hash(msg: &[u8]) -> G2 {
     <G2 as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::hash_to_curve(msg, CSUITE)
 }
@@ -170,7 +170,7 @@ pub fn verify(signature: &Signature, hashes: &[G2], public_keys: &[PublicKey]) -
 
 /// Verifies that the signature is the actual aggregated signature of messages - pubkeys.
 /// Calculated by `e(g1, signature) == \prod_{i = 0}^n e(pk_i, hash_i)`.
-#[cfg(feature = "pairing")]
+#[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
 pub fn verify_messages(
     signature: &Signature,
     messages: &[&[u8]],
@@ -263,7 +263,7 @@ mod tests {
 
     #[cfg(feature = "blst")]
     use blstrs::{G1Compressed, G1Projective as G1, Scalar as Fr};
-    #[cfg(feature = "pairing")]
+    #[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
     use paired::bls12_381::{Fr, G1Compressed, G1};
 
     #[test]
@@ -473,7 +473,7 @@ mod tests {
         Ok(res.into_affine()?)
     }
 
-    #[cfg(feature = "pairing")]
+    #[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
     fn hash_to_g1(msg: &[u8], suite: &[u8]) -> G1 {
         <G1 as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::hash_to_curve(msg, suite)
     }
@@ -482,7 +482,7 @@ mod tests {
         G1::hash_to_curve(msg, suite, &[])
     }
 
-    #[cfg(feature = "pairing")]
+    #[cfg(all(feature = "pairing", not(any(feature = "blst-portable", feature = "blst"))))]
     fn hash_to_g2(msg: &[u8], suite: &[u8]) -> G2 {
         <G2 as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::hash_to_curve(msg, suite)
     }


### PR DESCRIPTION
Very optional, I don't care if this comes in, but the features in the crate are not additive. This causes issues when a crate that depends on this needs to support each feature.

Also just fixes
```
cargo c --all-features
```

or any combination of features, which would fail to compile before. It doesn't indicate that it's using unnecessary dependencies, so I can add a compiler warning if that helps.