### PR TITLE
feat: add multicore feature to allow skipping the rayon dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,18 @@ jobs:
           keys:
             - cargo-v4-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
-          name: Test (nightly) (pairing)
+          name: Test (nightly) (pairing, multicore)
           command: cargo +nightly-2020-11-18 test -Zpackage-features --verbose --frozen --all
+          no_output_timeout: 15m
+          
+      - run:
+          name: Test (nightly) (blst, multicore)
+          command: cargo +nightly-2020-11-18 test -Zpackage-features --no-default-features --features blst,multicore --verbose --frozen --all
+          no_output_timeout: 15m
+
+      - run:
+          name: Test (nightly) (pairing)
+          command: cargo +nightly-2020-11-18 test -Zpackage-features --verbose --frozen --no-default-features --features pairing --all
           no_output_timeout: 15m
           
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ pre-release-commit-message = "chore(release): release {{version}}"
 pro-release-commit-message = "chore(release): starting development cycle for {{next_version}}"
 
 [dependencies]
-rayon = "1"
+rayon = { version = "1", optional = true }
 rand_core = "0.5.1"
 thiserror = "1.0"
 
@@ -36,7 +36,8 @@ members = [
 ]
 
 [features]
-default = ["pairing"]
+default = ["pairing", "multicore"]
+multicore = ["rayon"]
 pairing = [ "paired", "sha2", "hkdf" ]
 blst = [ "blst_lib", "blstrs" ]
 blst-portable = [ "blst_lib", "blst_lib/portable", "blstrs/portable" ]
@@ -48,3 +49,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.52"
 base64-serde = "0.5.1"
 rand_chacha = "0.2.2"
+
+[[example]]
+name = "verify"
+required-features = ["multicore"]

--- a/bls-signatures-ffi/Cargo.toml
+++ b/bls-signatures-ffi/Cargo.toml
@@ -12,9 +12,9 @@ crate-type = ["staticlib"]
 bls-signatures = { path = "..", default-features = false }
 rand = "0.7"
 libc = "0.2"
-rayon = "1.2.0"
 groupy = "0.3.0"
 
+rayon = { version = "1.2.0", optional = true }
 blstrs = { version = "0.2", optional = true }
 paired = { version = "0.21.0", optional = true }
 
@@ -22,7 +22,8 @@ paired = { version = "0.21.0", optional = true }
 cbindgen = { version = "0.13.1", default-features = false }
 
 [features]
-default = ["pairing"]
+default = ["pairing", "multicore"]
 pairing = [ "bls-signatures/pairing", "paired" ]
 blst = [ "bls-signatures/blst", "blstrs" ]
 blst-portable = [ "bls-signatures/blst-portable", "blstrs/portable" ]
+multicore = [ "bls-signatures/multicore", "rayon" ]

--- a/examples/verify.rs
+++ b/examples/verify.rs
@@ -1,7 +1,3 @@
-extern crate bls_signatures;
-extern crate rand;
-extern crate rayon;
-
 use std::time::{Duration, Instant};
 
 #[cfg(feature = "blst")]


### PR DESCRIPTION
This allows compilation to wasm with default-features=false and features = ['pairing']