### PR TITLE
Fix benches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           name: Test (nightly) (pairing, multicore)
           command: cargo +nightly-2020-11-18 test -Zpackage-features --verbose --frozen --all
           no_output_timeout: 15m
-          
+
       - run:
           name: Test (nightly) (blst, multicore)
           command: cargo +nightly-2020-11-18 test -Zpackage-features --no-default-features --features blst,multicore --verbose --frozen --all
@@ -89,7 +89,7 @@ jobs:
           name: Test (nightly) (pairing)
           command: cargo +nightly-2020-11-18 test -Zpackage-features --verbose --frozen --no-default-features --features pairing --all
           no_output_timeout: 15m
-          
+
       - run:
           name: Test (nightly) (blst)
           command: cargo +nightly-2020-11-18 test -Zpackage-features --no-default-features --features blst --verbose --frozen --all
@@ -146,7 +146,7 @@ jobs:
       - run:
           name: update apt
           command: apt-get update --fix-missing
-      
+
       - run:
           name: Install jq
           command: apt-get install jq -yqq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,10 @@ jobs:
           command: cargo +nightly-2020-11-18 test -Zpackage-features --no-default-features --features blst --verbose --frozen --all
           no_output_timeout: 15m
 
+      - run:
+          name: Check benches (nightly)
+          command: cargo +nightly-2020-11-18 check --all-targets --frozen --workspace
+
   rustfmt:
     docker:
       - image: filecoin/rust:latest

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -4,27 +4,18 @@ extern crate test;
 use test::{black_box, Bencher};
 
 use bls_signatures::*;
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
-
-const SEED: [u8; 16] = [
-    0x3d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc, 0x06, 0x54,
-];
+use rand::Rng;
 
 #[bench]
 fn bench_serialize_private_key_as_bytes(b: &mut Bencher) {
-    let rng = &mut XorShiftRng::from_seed(SEED);
-
-    let private_key = PrivateKey::generate(rng);
+    let private_key = PrivateKey::generate(&mut rand::thread_rng());
 
     b.iter(|| black_box(private_key.as_bytes()));
 }
 
 #[bench]
 fn bench_serialize_private_key_from_bytes(b: &mut Bencher) {
-    let rng = &mut XorShiftRng::from_seed(SEED);
-
-    let private_key = PrivateKey::generate(rng);
+    let private_key = PrivateKey::generate(&mut rand::thread_rng());
     let bytes = private_key.as_bytes();
 
     b.iter(|| black_box(PrivateKey::from_bytes(&bytes).unwrap()));
@@ -32,18 +23,14 @@ fn bench_serialize_private_key_from_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_serialize_public_key_as_bytes(b: &mut Bencher) {
-    let rng = &mut XorShiftRng::from_seed(SEED);
-
-    let public_key = PrivateKey::generate(rng).public_key();
+    let public_key = PrivateKey::generate(&mut rand::thread_rng()).public_key();
 
     b.iter(|| black_box(public_key.as_bytes()));
 }
 
 #[bench]
 fn bench_serialize_public_key_from_bytes(b: &mut Bencher) {
-    let rng = &mut XorShiftRng::from_seed(SEED);
-
-    let public_key = PrivateKey::generate(rng).public_key();
+    let public_key = PrivateKey::generate(&mut rand::thread_rng()).public_key();
     let bytes = public_key.as_bytes();
 
     b.iter(|| black_box(PublicKey::from_bytes(&bytes).unwrap()));
@@ -51,9 +38,8 @@ fn bench_serialize_public_key_from_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_serialize_signature_as_bytes(b: &mut Bencher) {
-    let rng = &mut XorShiftRng::from_seed(SEED);
-
-    let private_key = PrivateKey::generate(rng);
+    let mut rng = rand::thread_rng();
+    let private_key = PrivateKey::generate(&mut rng);
     let msg = (0..64).map(|_| rng.gen()).collect::<Vec<u8>>();
     let signature = private_key.sign(&msg);
 
@@ -62,9 +48,8 @@ fn bench_serialize_signature_as_bytes(b: &mut Bencher) {
 
 #[bench]
 fn bench_serialize_signature_from_bytes(b: &mut Bencher) {
-    let rng = &mut XorShiftRng::from_seed(SEED);
-
-    let private_key = PrivateKey::generate(rng);
+    let mut rng = rand::thread_rng();
+    let private_key = PrivateKey::generate(&mut rng);
     let msg = (0..64).map(|_| rng.gen()).collect::<Vec<u8>>();
     let signature = private_key.sign(&msg);
     let bytes = signature.as_bytes();

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -4,16 +4,11 @@ extern crate test;
 use test::{black_box, Bencher};
 
 use bls_signatures::*;
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
-
-const SEED: [u8; 16] = [
-    0x3d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc, 0x06, 0x54,
-];
+use rand::Rng;
 
 #[bench]
 fn sign_64b(b: &mut Bencher) {
-    let rng = &mut XorShiftRng::from_seed(SEED);
+    let rng = &mut rand::thread_rng();
 
     let private_key = PrivateKey::generate(rng);
     let msg: Vec<u8> = (0..64).map(|_| rng.gen()).collect();

--- a/benches/verify.rs
+++ b/benches/verify.rs
@@ -4,18 +4,13 @@ extern crate test;
 use test::{black_box, Bencher};
 
 use bls_signatures::*;
-use rand::{Rng, SeedableRng};
-use rand_xorshift::XorShiftRng;
-
-const SEED: [u8; 16] = [
-    0x3d, 0xbe, 0x62, 0x59, 0x8d, 0x31, 0x3d, 0x76, 0x32, 0x37, 0xdb, 0x17, 0xe5, 0xbc, 0x06, 0x54,
-];
+use rand::Rng;
 
 macro_rules! bench_verify {
     ($name:ident, $num:expr) => {
         #[bench]
         fn $name(b: &mut Bencher) {
-            let rng = &mut XorShiftRng::from_seed(SEED);
+            let rng = &mut rand::thread_rng();
             // generate private keys
             let private_keys: Vec<_> = (0..$num).map(|_| PrivateKey::generate(rng)).collect();
 
@@ -31,7 +26,7 @@ macro_rules! bench_verify {
                 .map(|(message, pk)| pk.sign(message))
                 .collect::<Vec<Signature>>();
 
-            let aggregated_signature = aggregate(&sigs);
+            let aggregated_signature = aggregate(&sigs).unwrap();
 
             let hashes = messages
                 .iter()


### PR DESCRIPTION
Fixes build failures with the benches. Did not look when did the benches go stale, but issues were:
- xorshift rng is no longer allowed
- aggregate now returns a result, which should always be ok in the benchmark (or require retry)

Added a ci run to make sure the benches do not go stale in the future. I'm not really so familiar with circleci so please review carefully. In the last commit I removed the whitespace errors git is nagging about (and my $EDITOR removes automatically).

I can't see xorshift => thread_rng() change being that important since none of the benched blocks includes rng use.