### PR TITLE
chore: update CircleCI to xcode 13.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
 
   publish_darwin_release:
     macos:
-      xcode: "12.5.0"
+      xcode: "13.4.1"
     working_directory: ~/crate
     steps:
       - run:


### PR DESCRIPTION
Version 12.5.0 doesn't seem to be supported anymore, hence upgrade to
the latest non-beta release.