### PR TITLE
feat: update blst and blstrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ bls12_381 = { version = "=0.7.0", optional = true, features = ["experimental"] }
 sha2 = { version = "0.9", optional = true }
 hkdf = { version = "0.11.0", optional = true }
 
-blst_lib = { version = "=0.3.9", optional = true, package = "blst" }
-blstrs = { version = "0.5.0", optional = true }
+blst_lib = { version = "=0.3.10", optional = true, package = "blst" }
+blstrs = { version = "0.6.0", optional = true }
 
 [workspace]
 members = [

--- a/bls-signatures-ffi/Cargo.toml
+++ b/bls-signatures-ffi/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.8"
 libc = "0.2"
 
 rayon = { version = "1.5.0", optional = true }
-blstrs = { version = "0.5.0", optional = true }
+blstrs = { version = "0.6.0", optional = true }
 bls12_381 = { version = "=0.7.0", optional = true, features = ["experimental"] }
 group = "0.12"
 


### PR DESCRIPTION
With this PR you can upgrade whole dependency trees. This should be released as v0.13 once merged.