### PR TITLE
chore: the FFI was never published, make it explicit

### DIFF
--- a/bls-signatures-ffi/Cargo.toml
+++ b/bls-signatures-ffi/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["sidke <sidney@carbonfive.com>", "dignifiedquire <dignifiedquire@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ["staticlib"]


### PR DESCRIPTION
The bls-signatures-ffi was never published on crates, make sure it also won't in the future by setting `publish` to `false`.