### PR TITLE
chore: relax the blst version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ bls12_381 = { version = "0.8.0", optional = true, features = ["experimental"] }
 sha2 = { version = "0.9", optional = true }
 hkdf = { version = "0.11.0", optional = true }
 
-blst_lib = { version = "=0.3.10", optional = true, package = "blst" }
+blst_lib = { version = "0.3.10", optional = true, package = "blst" }
 blstrs = { version = "0.7.0", optional = true }
 
 [workspace]


### PR DESCRIPTION
The latest blst v0.3.11 is compatible with v0.3.10, hence relax the version requirement and make it "v0.3.10 or greater".