### PR TITLE
feat: zeorize support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,14 @@ ff = "0.13"
 group = "0.13"
 pairing_lib = { version = "0.23.0", package = "pairing" }
 
-bls12_381 = { version = "0.8.0", optional = true, features = ["experimental"] }
+bls12_381 = { version = "0.8.0", optional = true, features = ["experimental", "zeroize"] }
 sha2 = { version = "0.9", optional = true }
 hkdf = { version = "0.11.0", optional = true }
 
 blst_lib = { version = "0.3.10", optional = true, package = "blst" }
 blstrs = { version = "0.7.0", optional = true }
+
+zeroize = { version = "1.7", features = ["derive"] }
 
 [features]
 default = ["pairing", "multicore"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ ff = "0.13"
 group = "0.13"
 pairing_lib = { version = "0.23.0", package = "pairing" }
 
-bls12_381 = { version = "0.8.0", optional = true, features = ["experimental", "zeroize"] }
+bls12_381 = { version = "0.8.0", optional = true, features = ["experimental" ] }
 sha2 = { version = "0.9", optional = true }
 hkdf = { version = "0.11.0", optional = true }
 
 blst_lib = { version = "0.3.10", optional = true, package = "blst" }
 blstrs = { version = "0.7.0", optional = true }
 
-zeroize = { version = "1.7", features = ["derive"] }
+zeroize = { version = "1.7", optional = true, features = ["derive"] }
 
 [features]
 default = ["pairing", "multicore"]
@@ -38,6 +38,8 @@ multicore = ["rayon"]
 pairing = [ "bls12_381", "sha2", "hkdf" ]
 blst = [ "blst_lib", "blstrs" ]
 blst-portable = [ "blst_lib", "blst_lib/portable", "blstrs/portable" ]
+
+zeroize = ["dep:zeroize", "bls12_381/zeroize"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ff = "0.13"
 group = "0.13"
 pairing_lib = { version = "0.23.0", package = "pairing" }
 
-bls12_381 = { version = "0.8.0", optional = true, features = ["experimental" ] }
+bls12_381 = { version = "0.8.0", optional = true, features = ["experimental"] }
 sha2 = { version = "0.9", optional = true }
 hkdf = { version = "0.11.0", optional = true }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -30,7 +30,7 @@ pub struct PublicKey(pub(crate) G1Projective);
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
 pub struct PrivateKey(pub(crate) Scalar)
 where
-    Scalar: DefaultIsZeroes;
+    Scalar: Zeroize + DefaultIsZeroes;
 
 impl From<G1Projective> for PublicKey {
     fn from(val: G1Projective) -> Self {

--- a/src/key.rs
+++ b/src/key.rs
@@ -10,6 +10,7 @@ use bls12_381::{hash_to_curve::HashToField, G1Affine, G1Projective, Scalar};
 use hkdf::Hkdf;
 #[cfg(feature = "pairing")]
 use sha2::{digest::generic_array::typenum::U48, digest::generic_array::GenericArray, Sha256};
+use zeroize::Zeroize;
 
 #[cfg(feature = "blst")]
 use blstrs::{G1Affine, G1Projective, G2Affine, Scalar};
@@ -26,7 +27,7 @@ pub(crate) const G1_COMPRESSED_SIZE: usize = 48;
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct PublicKey(pub(crate) G1Projective);
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
 pub struct PrivateKey(pub(crate) Scalar);
 
 impl From<G1Projective> for PublicKey {

--- a/src/key.rs
+++ b/src/key.rs
@@ -10,6 +10,7 @@ use bls12_381::{hash_to_curve::HashToField, G1Affine, G1Projective, Scalar};
 use hkdf::Hkdf;
 #[cfg(feature = "pairing")]
 use sha2::{digest::generic_array::typenum::U48, digest::generic_array::GenericArray, Sha256};
+#[cfg(feature = "zeroize")]
 use zeroize::{DefaultIsZeroes, Zeroize};
 
 #[cfg(feature = "blst")]
@@ -27,10 +28,18 @@ pub(crate) const G1_COMPRESSED_SIZE: usize = 48;
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct PublicKey(pub(crate) G1Projective);
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
-pub struct PrivateKey(pub(crate) Scalar)
-where
-    Scalar: Zeroize + DefaultIsZeroes;
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct PrivateKey(pub(crate) Scalar);
+
+#[cfg(feature = "zeroize")]
+impl Zeroize for PrivateKey {
+    fn zeroize(&mut self) {
+        self.0.zeroize()
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl DefaultIsZeroes for PrivateKey {}
 
 impl From<G1Projective> for PublicKey {
     fn from(val: G1Projective) -> Self {

--- a/src/key.rs
+++ b/src/key.rs
@@ -10,7 +10,7 @@ use bls12_381::{hash_to_curve::HashToField, G1Affine, G1Projective, Scalar};
 use hkdf::Hkdf;
 #[cfg(feature = "pairing")]
 use sha2::{digest::generic_array::typenum::U48, digest::generic_array::GenericArray, Sha256};
-use zeroize::Zeroize;
+use zeroize::{DefaultIsZeroes, Zeroize};
 
 #[cfg(feature = "blst")]
 use blstrs::{G1Affine, G1Projective, G2Affine, Scalar};
@@ -28,7 +28,9 @@ pub(crate) const G1_COMPRESSED_SIZE: usize = 48;
 pub struct PublicKey(pub(crate) G1Projective);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
-pub struct PrivateKey(pub(crate) Scalar);
+pub struct PrivateKey(pub(crate) Scalar)
+where
+    Scalar: DefaultIsZeroes;
 
 impl From<G1Projective> for PublicKey {
     fn from(val: G1Projective) -> Self {


### PR DESCRIPTION
This PR adds specific support for the Zeroize crate.

In particular, it allows the `PrivateKey` struct to derive `Zeroize`.

This translates into having the possibility to have secure PrivateKeys
since they won't leak any information if the memory address is accessed
after the variable is dropped.

The functionality relies on the fact that the crate `bls12_381` also
implements Zeorize, so nothing in the API has changed.

Solves #74 
